### PR TITLE
Tests and fixes for Django 2.0-3.0

### DIFF
--- a/grappelli/dashboard/dashboards.py
+++ b/grappelli/dashboard/dashboards.py
@@ -3,9 +3,9 @@
 """
 Module where grappelli dashboard classes are defined.
 """
+import six
 
 # DJANGO IMPORTS
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django import forms

--- a/grappelli/tests/models.py
+++ b/grappelli/tests/models.py
@@ -4,7 +4,7 @@
 from django.db import models
 from django.contrib.auth.models import User
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible
@@ -30,11 +30,11 @@ class Category(models.Model):
 @python_2_unicode_compatible
 class Entry(models.Model):
     title = models.CharField("Title", max_length=200)
-    category = models.ForeignKey(Category, related_name="entries", blank=True, null=True)
-    category_alt = models.ForeignKey(Category, related_name="entriesalt", to_field="name", blank=True, null=True)
+    category = models.ForeignKey(Category, related_name="entries", on_delete=models.SET_NULL, blank=True, null=True)
+    category_alt = models.ForeignKey(Category, related_name="entriesalt", to_field="name", on_delete=models.SET_NULL, blank=True, null=True)
     date = models.DateTimeField("Date")
     body = models.TextField("Body", blank=True)
-    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', User), related_name="entries")
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', User), on_delete=models.CASCADE, related_name="entries")
     createdate = models.DateField("Date (Create)", auto_now_add=True)
     updatedate = models.DateField("Date (Update)", auto_now=True)
 

--- a/grappelli/tests/test_related.py
+++ b/grappelli/tests/test_related.py
@@ -2,13 +2,14 @@
 
 # PYTHON IMPORTS
 import datetime
+import six
 
 # DJANGO IMPORTS
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
-from django.utils import six, translation, timezone
+from django.urls import reverse
+from django.utils import translation, timezone
 
 try:
     import json

--- a/grappelli/tests/test_switch.py
+++ b/grappelli/tests/test_switch.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth.models import User, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
@@ -39,7 +39,7 @@ class SwitchTests(TestCase):
         # add permissions for editor001
         content_type = ContentType.objects.get_for_model(Category)
         permissions = Permission.objects.filter(content_type=content_type)
-        self.editor_1.user_permissions = permissions
+        self.editor_1.user_permissions.set(permissions)
 
         # add categories
         for i in range(100):

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 universal=1
 
 [egg_info]
-tag_build = +atl.1.0
+tag_build = +atl.2.0
 tag_date = false

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -25,15 +25,14 @@ INSTALLED_APPS = (
     'grappelli',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
 )
 
 ROOT_URLCONF = 'grappelli.tests.urls'

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,19 @@
 [tox]
-envlist = py{27,34,35}
+envlist =
+    py{27,37}-django111
+    py37-django{20,22,30}
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
-    -rrequirements/requirements-testing.txt
     coverage
+    django111: Django>=1.11,<2.0
+    django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
+    pytest-django
+    pytest
+    six
+
 commands = ./runtests.py {posargs}


### PR DESCRIPTION
This work assumes we would like to remain on v2.10.2 for now, but ensure that we can still use it with Django 2.0-3.0. Which we can.